### PR TITLE
chore: run lint when ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,24 @@ on:
       - "**"
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check es-lint rules
+        run: npm run lint
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Type of PR (Check the boxes that apply)*

- [ ] Bug Fix
- [ ] New Feature
- [x] Improvement
- [ ] Others

## Changes (Release Note)*

Describe the changes made.  
- `npm run lint` when PR is opened.

## Test Plan

Describe your test plan for the changes made.  

## Related Issues

Mention any related issues linked to this PR.  


## Additional Context
I am contemplating incorporating type-check(build), lint or others in one job. But, I could not think of the deservedly good job name.
